### PR TITLE
feat(Radio): support custom render in options

### DIFF
--- a/packages/sqi-web/src/radio/RadioGroup.tsx
+++ b/packages/sqi-web/src/radio/RadioGroup.tsx
@@ -2,7 +2,7 @@
 import React, { forwardRef, useCallback, useContext, useId, useMemo } from 'react';
 import clsx from 'clsx';
 import { useMergeProps, useMergeState } from '@sqi-ui/hooks';
-import { isArray, isNumber, isString } from '@sqi-ui/utils';
+import { isArray, isFunction, isNumber, isString } from '@sqi-ui/utils';
 import { ConfigContext } from '../config-provider/context';
 import RadioGroupContext from './context';
 import Radio from './Radio';
@@ -31,6 +31,7 @@ const RadioGroup = forwardRef<HTMLDivElement, RadioGroupProps>((baseProps, ref) 
     disabled,
     size,
     buttonVariant,
+    renderOptions,
     onChange,
     appearance,
     options,
@@ -58,14 +59,26 @@ const RadioGroup = forwardRef<HTMLDivElement, RadioGroupProps>((baseProps, ref) 
   const Comp = appearance === 'button' ? RadioButton : Radio;
 
   if (isArray(options) && options.length > 0) {
+    const isCustomRender = isFunction(renderOptions);
+
     renderChildren = options.map((item) => {
       if (isString(item) || isNumber(item)) {
+        const isChecked = isCustomRender ? controlValue === item : value === item;
+        const renderNode = isCustomRender
+          ? () => renderOptions({ label: item, value: item, checked: isChecked })
+          : item;
+
         return (
-          <Comp key={item.toString()} disabled={disabled} value={item} checked={value === item}>
-            {item}
+          <Comp key={item.toString()} disabled={disabled} value={item} checked={isChecked}>
+            {renderNode}
           </Comp>
         );
       }
+      // improve perf: 在自定义渲染的情况下，选中更改是需要重新 render 以确保使用侧的 checked 更新视图
+      // 但非自定义渲染（配置项）下，不关注某一项状态，因此没必要始终让 item 和 controlValue 做对比，减少使用侧的 render
+      const isChecked = isCustomRender ? controlValue === item.value : value === item.value;
+      // 必须包装成 function，否则 Radio 组件无法视为自定义渲染
+      const renderNode = isCustomRender ? () => renderOptions({ ...item, checked: isChecked }) : item.label;
 
       return (
         <Comp
@@ -74,11 +87,11 @@ const RadioGroup = forwardRef<HTMLDivElement, RadioGroupProps>((baseProps, ref) 
           style={item.style}
           disabled={item.disabled || disabled}
           value={item.value}
-          checked={value === item.value}
+          checked={isChecked}
           id={item.id}
           title={item.title}
         >
-          {item.label}
+          {renderNode}
         </Comp>
       );
     });

--- a/packages/sqi-web/src/radio/demos/options.tsx
+++ b/packages/sqi-web/src/radio/demos/options.tsx
@@ -1,18 +1,13 @@
 import React from 'react';
-import { Radio } from '@sqi-ui/web';
+import { Button, Divider, Radio } from '@sqi-ui/web';
 
 export default function Demo() {
   return (
     <>
-      <Radio.Group
-        defaultValue={3}
-        options={[
-          { label: 'Radio 1', value: 1 },
-          { label: 'Radio 2', value: 2 },
-          { label: 'Radio 3', value: 3 },
-        ]}
-      />
+      <Divider text="Base" />
+      <Radio.Group defaultValue="Radio 1" options={['Radio 1', 'Radio 2', 'Radio 3']} />
 
+      <Divider text="Button appearance" />
       <Radio.Group
         defaultValue={3}
         appearance="button"
@@ -22,6 +17,21 @@ export default function Demo() {
           { label: 'Radio 2', value: 2 },
           { label: 'Radio 3', value: 3 },
         ]}
+      />
+
+      <Divider text="Custom render" />
+      <Radio.Group
+        defaultValue={3}
+        options={[
+          { label: 'Radio 1', value: 1 },
+          { label: 'Radio 2', value: 2 },
+          { label: 'Radio 3', value: 3 },
+        ]}
+        renderOptions={(params) => (
+          <Button tabIndex={-1} type="primary" variant={params.checked ? 'default' : 'outline'}>
+            {params.label}
+          </Button>
+        )}
       />
     </>
   );

--- a/packages/sqi-web/src/radio/type.ts
+++ b/packages/sqi-web/src/radio/type.ts
@@ -20,6 +20,10 @@ export interface RadioGroupContextState {
   onChange?: (value: RadioChangeEvent) => void;
 }
 
+export interface CustomRenderItem extends RadioOptions {
+  checked: boolean;
+}
+
 export interface RadioGroupProps {
   className?: string;
   style?: CSSProperties;
@@ -61,14 +65,18 @@ export interface RadioGroupProps {
    */
   options?: RadioOptions[] | string[] | number[];
   /**
+   * @description 自定义渲染内容, 仅使用 options 时生效
+   */
+  renderOptions?: (params: CustomRenderItem) => ReactNode;
+  /**
    * @description 选中值发生变化时触发
    */
   onChange?: (e: RadioChangeEvent) => void;
 }
 
 export interface RadioOptions {
-  label: ReactNode;
-  value: RadioValue;
+  label?: ReactNode;
+  value?: RadioValue;
   disabled?: boolean;
   className?: string;
   style?: CSSProperties;
@@ -79,10 +87,9 @@ export interface RadioOptions {
 
 export interface RadioProps
   extends Omit<BaseCheckboxProps, 'type' | 'prefixCls' | 'size' | 'onChange' | 'value' | 'children'> {
-  children?: ReactNode | (({ checked }: { checked: boolean }) => ReactNode);
+  children?: ReactNode | (({ checked }: { checked: boolean }) => ReactNode); // 单独使用时，所有 props 由外部控制，因此内部只回传 checked 即可
   /**
-   * @description 内部 props，不要使用它，除非你知道自己在干什么
-   * @internal
+   * @private 内部 props，不要使用它，除非你知道自己在干什么
    */
   _IS_BUTTON_?: boolean;
   /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for custom rendering of radio group options via a new prop, enabling more flexible and personalized option displays.
* **Documentation**
  * Updated demo examples to showcase the new custom rendering feature and various radio group presentations.
* **Refactor**
  * Enhanced type definitions to support the new custom rendering capability and clarified property usage in component types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->