### PR TITLE
refactor: remove `autoLockScroll` api, clean code

### DIFF
--- a/packages/sqi-web/src/_common/Portal.tsx
+++ b/packages/sqi-web/src/_common/Portal.tsx
@@ -14,7 +14,6 @@ export interface PortalProps {
   getContainer?: PortalContainer;
   children: React.ReactNode;
   open?: boolean;
-  autoLockScroll?: boolean;
   rootStyle?: React.CSSProperties;
 }
 
@@ -31,14 +30,11 @@ function getAttachNode(getContainer: PortalProps['getContainer']): HTMLElement |
 }
 
 const Portal = forwardRef<HTMLDivElement, PortalProps>((props, ref) => {
-  const { getContainer, prefixCls, children, open = true, rootStyle, autoLockScroll = true } = props;
+  const { getContainer, prefixCls, children, open = true, rootStyle } = props;
 
-  const [isMounted, setIsMounted] = useState(false);
   const [containerWrapper, setContainerWrapper] = useState<HTMLDivElement | null>(null);
-  const [customizeParent, setCustomizeParent] = useState<HTMLElement | null>(() => getAttachNode(getContainer));
+  const [customizeParent, setCustomizeParent] = useState<HTMLElement | null>(null);
   const mergedParentNode = customizeParent || document.body;
-
-  const shouldRender = open || isMounted;
 
   useEffect(() => {
     const newParentNode = getAttachNode(getContainer);
@@ -46,7 +42,7 @@ const Portal = forwardRef<HTMLDivElement, PortalProps>((props, ref) => {
   }, [getContainer]);
 
   const createContainerNode = () => {
-    if (!isBrowser) return null;
+    if (!isBrowser || containerWrapper) return null;
 
     const node = document.createElement('div');
     if (prefixCls) {
@@ -58,13 +54,13 @@ const Portal = forwardRef<HTMLDivElement, PortalProps>((props, ref) => {
     }
 
     node.setAttribute('data-portal', 'true');
-    return node;
+    setContainerWrapper(node);
   };
 
   useIsomorphicLayoutEffect(() => {
     if (!isBrowser) return;
     if (open) {
-      if (!containerWrapper) setContainerWrapper(() => createContainerNode());
+      createContainerNode();
     } else {
       setContainerWrapper(null);
     }
@@ -73,45 +69,24 @@ const Portal = forwardRef<HTMLDivElement, PortalProps>((props, ref) => {
   useImperativeHandle(ref, () => containerWrapper as HTMLDivElement, [containerWrapper]);
 
   useIsomorphicLayoutEffect(() => {
-    // 兼容显示隐藏时（非销毁）的滚动条状态
-    // Portal 暂时没做 cache 节点，因此使用此方式来兼容和 CSSMotion 的隐藏交互
-    if (autoLockScroll === false) {
-      document.body.style.overflow = '';
-    } else if (autoLockScroll && containerWrapper) {
-      document.body.style.overflow = 'hidden';
-    }
-  }, [autoLockScroll, containerWrapper]);
-
-  useIsomorphicLayoutEffect(() => {
     if (!isBrowser || !containerWrapper) return;
 
-    const attachToParent = () => {
-      if (!containerWrapper.parentNode) {
-        mergedParentNode.appendChild(containerWrapper);
-        // if (autoLockScroll) document.body.style.overflow = 'hidden';
-        setIsMounted(true);
-      }
-    };
+    const attachToParent = () => !containerWrapper.parentNode && mergedParentNode.appendChild(containerWrapper);
 
-    const detachFromParent = () => {
-      if (containerWrapper.parentNode) {
-        containerWrapper.parentNode.removeChild(containerWrapper);
-        if (autoLockScroll) document.body.style.overflow = '';
-        setIsMounted(false);
-      }
-    };
+    const detachFromParent = () => containerWrapper.parentNode?.removeChild(containerWrapper);
 
-    if (open) attachToParent();
-    else detachFromParent();
+    if (open) {
+      attachToParent();
+    } else {
+      detachFromParent();
+    }
 
     return () => {
-      if (containerWrapper.parentNode) {
-        detachFromParent();
-      }
+      detachFromParent();
     };
   }, [open, containerWrapper]);
 
-  if (!(shouldRender && children)) return null;
+  if (!(open && children)) return null;
 
   return containerWrapper ? createPortal(children, containerWrapper) : null;
 });

--- a/packages/sqi-web/src/_common/demos/css-motion-portal.tsx
+++ b/packages/sqi-web/src/_common/demos/css-motion-portal.tsx
@@ -31,9 +31,9 @@ export default function Demo() {
       </Space>
 
       <CSSMotion ref={motionRef} timeout={500} name="demo" mountOnEnter preEnter unmountOnExit={unmountDestroy}>
-        {({ className, status }) => {
+        {({ className }) => {
           return (
-            <Portal autoLockScroll={status !== 'exited' && status !== 'unmounted'}>
+            <Portal>
               <div className={className} style={styles}>
                 This is a container use Portal
               </div>

--- a/packages/sqi-web/src/trigger/Trigger.tsx
+++ b/packages/sqi-web/src/trigger/Trigger.tsx
@@ -93,7 +93,7 @@ const Trigger = forwardRef<any, TriggerProps>((baseProps, ref) => {
     <>
       <ResizeObserverComponent ref={referenceRef}>{children}</ResizeObserverComponent>
       {popup ? (
-        <Portal getContainer={getContainer} autoLockScroll={false}>
+        <Portal getContainer={getContainer}>
           {/* {<div ref={arrowRef} className={`${prefixCls}-trigger-arrow`}></div>} */}
           <div
             className={`${prefixCls}-trigger`}


### PR DESCRIPTION
Portal 组件不应涉及额外的dom操作

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 无新增功能。

* **修复**
  * 移除了 Portal 组件中的滚动锁定（autoLockScroll）功能，简化了相关状态管理和容器节点生命周期处理，提升了组件的简洁性和稳定性。用户在使用弹窗、浮层等场景时将不再自动锁定页面滚动。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->