### PR TITLE
style: improve popup style

### DIFF
--- a/packages/sqi-web/src/popup/Popup.tsx
+++ b/packages/sqi-web/src/popup/Popup.tsx
@@ -11,7 +11,7 @@ const defaultProps: PopupProps = {
   placement: 'top',
   showArrow: true,
   destroyOnClose: true,
-  offset: 2,
+  offset: 6,
 };
 
 const Popup = forwardRef<HTMLElement, PopupProps>((baseProps, ref) => {

--- a/packages/sqi-web/src/popup/index.md
+++ b/packages/sqi-web/src/popup/index.md
@@ -60,7 +60,7 @@ group:
 | content        | Popup 内容               | `ReactNode`                                          | -      |
 | showArrow      | 是否展示箭头             | `boolean`                                            | `true` |
 | destroyOnClose | 隐藏时是否销毁           | `boolean`                                            | `true` |
-| offset         | 元素相对于触发元素的距离 | `number`                                             | `4`    |
+| offset         | 元素相对于触发元素的距离 | `number`                                             | `6`    |
 | styles         | style 语法糖             | `{ content?: CSSProperties; arrow?: CSSProperties;}` | -      |
 | classNames     | className 语法糖         | `{ content?: string; arrow?: string;}`               | -      |
 

--- a/packages/sqi-web/src/popup/style/_var.scss
+++ b/packages/sqi-web/src/popup/style/_var.scss
@@ -8,7 +8,7 @@ $popup-text-color: $text-color-primary;
 // 间距
 $popup-padding: $padding-sm;
 $popup-content-line-height: $text-line-height-md;
-$popup-arrow-size: 9px;
+$popup-arrow-size: 10px;
 $popup-arrow-width: $popup-arrow-size;
 $popup-arrow-height: $popup-arrow-size;
 $popup-content-arrow-spacer: $margin-lg;

--- a/packages/sqi-web/src/popup/type.ts
+++ b/packages/sqi-web/src/popup/type.ts
@@ -41,7 +41,7 @@ export interface PopupProps extends PickTriggerProps {
   destroyOnClose?: boolean;
   /**
    * @description popper 元素相对于触发元素的距离
-   * @default 2
+   * @default 4
    */
   offset?: number;
   styles?: {

--- a/packages/sqi-web/src/popup/type.ts
+++ b/packages/sqi-web/src/popup/type.ts
@@ -41,7 +41,7 @@ export interface PopupProps extends PickTriggerProps {
   destroyOnClose?: boolean;
   /**
    * @description popper 元素相对于触发元素的距离
-   * @default 4
+   * @default 6
    */
   offset?: number;
   styles?: {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 样式
  - Popup 默认偏移量提升至 6，弹出层与触发元素的默认间距更大。
  - 弹出层箭头尺寸增至 10px，视觉更清晰。

- 文档
  - 更新 Popup API，offset 默认值说明调整为 6，与实际表现一致。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->